### PR TITLE
Implement config-style flag

### DIFF
--- a/cmd/backup/command.go
+++ b/cmd/backup/command.go
@@ -29,7 +29,11 @@ func newCommand() *command {
 
 // runAsCommand executes a backup run for each configuration that is available
 // and then returns
-func (c *command) runAsCommand() error {
+func (c *command) runAsCommand(style string) error {
+	if style != "envfile" {
+		return fmt.Errorf("config style %s not implemented", style)
+	}
+
 	configurations, err := sourceConfiguration(configStrategyEnv)
 	if err != nil {
 		return errwrap.Wrap(err, "error loading env vars")
@@ -50,7 +54,11 @@ type foregroundOpts struct {
 
 // runInForeground starts the program as a long running process, scheduling
 // a job for each configuration that is available.
-func (c *command) runInForeground(opts foregroundOpts) error {
+func (c *command) runInForeground(opts foregroundOpts, style string) error {
+	if style != "envfile" {
+		return fmt.Errorf("config style %s not implemented", style)
+	}
+
 	c.cr = cron.New(
 		cron.WithParser(
 			cron.NewParser(

--- a/cmd/backup/main.go
+++ b/cmd/backup/main.go
@@ -10,6 +10,7 @@ import (
 func main() {
 	foreground := flag.Bool("foreground", false, "run the tool in the foreground")
 	profile := flag.String("profile", "", "collect runtime metrics and log them periodically on the given cron expression")
+	configStyle := flag.String("config-style", "envfile", "configuration style: envfile or labels")
 	flag.Parse()
 
 	c := newCommand()
@@ -17,8 +18,8 @@ func main() {
 		opts := foregroundOpts{
 			profileCronExpression: *profile,
 		}
-		c.must(c.runInForeground(opts))
+		c.must(c.runInForeground(opts, *configStyle))
 	} else {
-		c.must(c.runAsCommand())
+		c.must(c.runAsCommand(*configStyle))
 	}
 }


### PR DESCRIPTION
## Summary
- add `--config-style` flag to main
- propagate style choice to command handlers

## Testing
- `go test ./...` *(fails: module downloads blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686033ec54b88327a34c99f3bffb32e6