### PR TITLE
Implement volume listing helper

### DIFF
--- a/internal/labels/client.go
+++ b/internal/labels/client.go
@@ -1,0 +1,41 @@
+// Copyright 2024 - offen.software <hioffen@posteo.de>
+// SPDX-License-Identifier: MPL-2.0
+
+package labels
+
+import (
+	"context"
+
+	"github.com/docker/docker/api/types/volume"
+	"github.com/docker/docker/client"
+	"github.com/offen/docker-volume-backup/internal/errwrap"
+)
+
+func newDockerClient() (*client.Client, error) {
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		return nil, errwrap.Wrap(err, "error creating docker client")
+	}
+	return cli, nil
+}
+
+func listVolumes(cli interface {
+	VolumeList(ctx context.Context, options volume.ListOptions) (volume.ListResponse, error)
+}) ([]*volume.Volume, error) {
+	resp, err := cli.VolumeList(context.Background(), volume.ListOptions{})
+	if err != nil {
+		return nil, errwrap.Wrap(err, "error listing volumes")
+	}
+	return resp.Volumes, nil
+}
+
+// ListVolumes returns all Docker volumes using a new Docker client derived from
+// the current environment.
+func ListVolumes() ([]*volume.Volume, error) {
+	cli, err := newDockerClient()
+	if err != nil {
+		return nil, err
+	}
+	defer cli.Close()
+	return listVolumes(cli)
+}

--- a/internal/labels/client_test.go
+++ b/internal/labels/client_test.go
@@ -1,0 +1,57 @@
+// Copyright 2024 - offen.software <hioffen@posteo.de>
+// SPDX-License-Identifier: MPL-2.0
+
+package labels
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/docker/docker/api/types/volume"
+)
+
+type mockVolumeClient struct {
+	result volume.ListResponse
+	err    error
+}
+
+func (m *mockVolumeClient) VolumeList(context.Context, volume.ListOptions) (volume.ListResponse, error) {
+	return m.result, m.err
+}
+
+func TestListVolumesInternal(t *testing.T) {
+	tests := []struct {
+		name        string
+		client      *mockVolumeClient
+		expected    []*volume.Volume
+		expectError bool
+	}{
+		{
+			name: "success",
+			client: &mockVolumeClient{
+				result: volume.ListResponse{Volumes: []*volume.Volume{{Name: "foo"}, {Name: "bar"}}},
+			},
+			expected: []*volume.Volume{{Name: "foo"}, {Name: "bar"}},
+		},
+		{
+			name:        "error",
+			client:      &mockVolumeClient{err: errors.New("explode")},
+			expected:    nil,
+			expectError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := listVolumes(test.client)
+			if (err != nil) != test.expectError {
+				t.Errorf("unexpected error value %v", err)
+			}
+			if !reflect.DeepEqual(result, test.expected) {
+				t.Errorf("expected %v, got %v", test.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add `internal/labels/client.go` with helpers for creating a Docker client and listing volumes
- cover helper with unit tests

## Testing
- `go test ./...` *(fails: fetching modules requires network access)*

------
https://chatgpt.com/codex/tasks/task_e_686170f39e20832782fe56355aac9da2