### PR TITLE
Implement volume label scanner

### DIFF
--- a/internal/labels/scanner.go
+++ b/internal/labels/scanner.go
@@ -1,0 +1,39 @@
+package labels
+
+import (
+	"context"
+	"strings"
+
+	"github.com/docker/docker/api/types/volume"
+	"github.com/offen/docker-volume-backup/internal/errwrap"
+)
+
+func scanVolumeLabels(cli interface {
+	VolumeList(ctx context.Context, options volume.ListOptions) (volume.ListResponse, error)
+}) (map[string]map[string]string, error) {
+	vols, err := listVolumes(cli)
+	if err != nil {
+		return nil, errwrap.Wrap(err, "error scanning volume labels")
+	}
+	result := map[string]map[string]string{}
+	for _, v := range vols {
+		labels := map[string]string{}
+		for key, value := range v.Labels {
+			if strings.HasPrefix(key, Prefix) {
+				labels[strings.TrimPrefix(key, Prefix)] = value
+			}
+		}
+		if len(labels) > 0 {
+			result[v.Name] = labels
+		}
+	}
+	return result, nil
+}
+
+// ScanVolumeLabels returns a mapping of volume names to their relevant labels.
+// The provided client is used to look up the list of volumes.
+func ScanVolumeLabels(cli interface {
+	VolumeList(ctx context.Context, options volume.ListOptions) (volume.ListResponse, error)
+}) (map[string]map[string]string, error) {
+	return scanVolumeLabels(cli)
+}

--- a/internal/labels/scanner_test.go
+++ b/internal/labels/scanner_test.go
@@ -1,0 +1,59 @@
+package labels
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/docker/docker/api/types/volume"
+	"github.com/offen/docker-volume-backup/internal/errwrap"
+)
+
+func TestScanVolumeLabels(t *testing.T) {
+	tests := []struct {
+		name        string
+		client      *mockVolumeClient
+		expected    map[string]map[string]string
+		expectError bool
+	}{
+		{
+			name: "success",
+			client: &mockVolumeClient{
+				result: volume.ListResponse{Volumes: []*volume.Volume{
+					{Name: "foo", Labels: map[string]string{Prefix + "schedule": "daily", Prefix + "path": "/data", "ignored": "x"}},
+					{Name: "bar", Labels: map[string]string{"other": "y", Prefix + "path": "/var"}},
+				}},
+			},
+			expected: map[string]map[string]string{
+				"foo": {"schedule": "daily", "path": "/data"},
+				"bar": {"path": "/var"},
+			},
+		},
+		{
+			name: "none",
+			client: &mockVolumeClient{
+				result: volume.ListResponse{Volumes: []*volume.Volume{{Name: "foo"}}},
+			},
+			expected: map[string]map[string]string{},
+		},
+		{
+			name:        "error",
+			client:      &mockVolumeClient{err: errExample},
+			expected:    nil,
+			expectError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := scanVolumeLabels(test.client)
+			if (err != nil) != test.expectError {
+				t.Errorf("unexpected error value %v", err)
+			}
+			if !reflect.DeepEqual(result, test.expected) {
+				t.Errorf("expected %v, got %v", test.expected, result)
+			}
+		})
+	}
+}
+
+var errExample = errwrap.Wrap(nil, "boom")


### PR DESCRIPTION
## Summary
- add a scanner that collects labels from Docker volumes
- include tests for the scanner

## Testing
- `golangci-lint run` *(fails: can't load config)*
- `go test ./...` *(fails to download modules: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68617855fed083278c9b3ded377546ef