### PR TITLE
Implement basic label parser

### DIFF
--- a/internal/labels/parser_basic.go
+++ b/internal/labels/parser_basic.go
@@ -3,6 +3,7 @@ package labels
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/offen/docker-volume-backup/internal/errwrap"
 	"github.com/robfig/cron/v3"

--- a/internal/labels/parser_basic.go
+++ b/internal/labels/parser_basic.go
@@ -1,0 +1,55 @@
+package labels
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/offen/docker-volume-backup/internal/errwrap"
+	"github.com/robfig/cron/v3"
+)
+
+// Config holds the subset of configuration derived from volume labels.
+type Config struct {
+	BackupCronExpression string
+	BackupArchive        string
+	BackupRetentionDays  int32
+}
+
+// parseBasicLabels converts a set of volume labels into a Config.
+// Supported keys are:
+//   - schedule: cron expression controlling when to run a backup
+//   - target:   backup archive path
+//   - rotation: number of days to keep backups
+func parseBasicLabels(labels map[string]string) (Config, error) {
+	trimmed := map[string]string{}
+	for key, value := range labels {
+		if strings.HasPrefix(key, Prefix) {
+			trimmed[strings.TrimPrefix(key, Prefix)] = value
+			continue
+		}
+		trimmed[key] = value
+	}
+
+	var c Config
+
+	if v, ok := trimmed["schedule"]; ok {
+		if _, err := cron.ParseStandard(v); err != nil {
+			return c, errwrap.Wrap(err, fmt.Sprintf("invalid schedule value %s", v))
+		}
+		c.BackupCronExpression = v
+	}
+
+	if v, ok := trimmed["target"]; ok {
+		c.BackupArchive = v
+	}
+
+	if v, ok := trimmed["rotation"]; ok {
+		days, err := strconv.Atoi(v)
+		if err != nil {
+			return c, errwrap.Wrap(err, fmt.Sprintf("invalid rotation value %s", v))
+		}
+		c.BackupRetentionDays = int32(days)
+	}
+
+	return c, nil
+}

--- a/internal/labels/parser_basic_test.go
+++ b/internal/labels/parser_basic_test.go
@@ -1,0 +1,80 @@
+package labels
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestParseBasicLabels(t *testing.T) {
+	tests := []struct {
+		name        string
+		labels      map[string]string
+		expected    Config
+		expectError bool
+	}{
+		{
+			name: "complete",
+			labels: map[string]string{
+				Prefix + "schedule": "@daily",
+				Prefix + "target":   "/archive",
+				Prefix + "rotation": "7",
+			},
+			expected: Config{
+				BackupCronExpression: "@daily",
+				BackupArchive:        "/archive",
+				BackupRetentionDays:  7,
+			},
+		},
+		{
+			name: "partial",
+			labels: map[string]string{
+				Prefix + "schedule": "0 0 * * *",
+			},
+			expected: Config{
+				BackupCronExpression: "0 0 * * *",
+			},
+		},
+		{
+			name: "invalid schedule",
+			labels: map[string]string{
+				Prefix + "schedule": "never",
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid rotation",
+			labels: map[string]string{
+				Prefix + "rotation": "abc",
+			},
+			expectError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := parseBasicLabels(test.labels)
+			if (err != nil) != test.expectError {
+				t.Fatalf("unexpected error state %v", err)
+			}
+			if !test.expectError && !reflect.DeepEqual(result, test.expected) {
+				t.Errorf("expected %v, got %v", test.expected, result)
+			}
+		})
+	}
+}
+
+func Example_parseBasicLabels() {
+	cfg, _ := parseBasicLabels(map[string]string{
+		Prefix + "schedule": "@hourly",
+		Prefix + "target":   "/archive",
+		Prefix + "rotation": "3",
+	})
+	fmt.Println(cfg.BackupCronExpression)
+	fmt.Println(cfg.BackupArchive)
+	fmt.Println(cfg.BackupRetentionDays)
+	// Output:
+	// @hourly
+	// /archive
+	// 3
+}


### PR DESCRIPTION
## Summary
- add `parseBasicLabels` in internal/labels
- provide Config struct for schedule, target and rotation labels
- add parser tests with usage example
- handle label prefix in parser and tests

## Testing
- `go fmt ./...`
- `golangci-lint run` *(fails: can't unmarshal config)*

------
https://chatgpt.com/codex/tasks/task_e_68617fe6e37083279008e8c587675f10