### PR TITLE
Add parser integration test and expand Swarm documentation

### DIFF
--- a/ISSUE_PLAN.md
+++ b/ISSUE_PLAN.md
@@ -155,6 +155,36 @@ This plan outlines a series of GitHub issues for adding Docker label driven conf
 - **Priority:** P3
 - **Predecessor:** Issues 1 and 2
 
+## Issue 15 - Discover Swarm node for volumes
+- **Description:** When Docker runs in Swarm mode, determine the node owning each labeled volume using `docker volume inspect`.
+- **Objective:** Provide the information needed to back up volumes on the correct host.
+- **Complexity:** M
+- **Expected Result:** Helper function `volumeNodeID(name string) (string, error)` returns the Swarm node ID or empty string when not in Swarm mode.
+- **Advice:** Extend the Docker client helper to read the `NodeID` field from the volume inspect output.
+- **Labels:** enhancement
+- **Priority:** P3
+- **Predecessor:** Issue 8
+
+## Issue 16 - Spawn helper container on volume node
+- **Description:** Start a short-lived backup container on the node that owns a labeled volume based on the node ID information.
+- **Objective:** Allow centrally managed backups while ensuring volumes are archived on their respective nodes.
+- **Complexity:** L
+- **Expected Result:** The main service creates a helper container with the appropriate Swarm constraint or remote `DOCKER_HOST` setting.
+- **Advice:** Reuse `docker run` options from existing backup logic and clean up the helper container after completion.
+- **Labels:** enhancement
+- **Priority:** P3
+- **Predecessor:** Issue 15
+
+## Issue 17 - Document and test Swarm helper workflow
+- **Description:** Update documentation and integration tests to cover the helper container approach for Swarm setups.
+- **Objective:** Demonstrate how backups work across Swarm nodes and ensure reliability.
+- **Complexity:** M
+- **Expected Result:** `docs/how-tos/use-with-docker-swarm.md` explains the helper mechanism and integration tests exercise it.
+- **Advice:** Add a new test scenario under `test/swarm` orchestrating multiple nodes with a labeled volume.
+- **Labels:** documentation, test
+- **Priority:** P2
+- **Predecessor:** Issue 16
+
 ```mermaid
 graph TD
     I1("1: config-style flag") --> I2("2: label prefix constant")
@@ -172,4 +202,7 @@ graph TD
     I11 --> I12("12: documentation")
     I1 --> I13("13: custom prefix")
     I2 --> I13
+    I12 --> I15("15: discover node")
+    I15 --> I16("16: helper container")
+    I16 --> I17("17: swarm docs & tests")
 ```

--- a/internal/labels/parser_advanced_test.go
+++ b/internal/labels/parser_advanced_test.go
@@ -68,6 +68,35 @@ func TestParseAdvancedLabels(t *testing.T) {
 			},
 			expectError: true,
 		},
+		{
+			name: "without prefix",
+			labels: map[string]string{
+				"gpg-passphrase":     "abc",
+				"notification-level": "ERROR",
+				"smtp-port":          "80",
+			},
+			expected: Config{
+				GpgPassphrase:     "abc",
+				NotificationLevel: "error",
+				EmailSMTPPort:     80,
+			},
+		},
+		{
+			name: "empty lists",
+			labels: map[string]string{
+				Prefix + "age-public-keys":   "",
+				Prefix + "notification-urls": "",
+			},
+			expected: Config{},
+		},
+		{
+			name: "whitespace lists",
+			labels: map[string]string{
+				Prefix + "age-public-keys":   " , ",
+				Prefix + "notification-urls": " ,",
+			},
+			expected: Config{},
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/labels/parser_basic_test.go
+++ b/internal/labels/parser_basic_test.go
@@ -49,6 +49,32 @@ func TestParseBasicLabels(t *testing.T) {
 			},
 			expectError: true,
 		},
+		{
+			name: "without prefix",
+			labels: map[string]string{
+				"schedule": "@weekly",
+				"target":   "/var/data",
+				"rotation": "5",
+			},
+			expected: Config{
+				BackupCronExpression: "@weekly",
+				BackupArchive:        "/var/data",
+				BackupRetentionDays:  5,
+			},
+		},
+		{
+			name: "mixed prefix",
+			labels: map[string]string{
+				Prefix + "schedule": "@hourly",
+				"target":            "/tmp",
+				Prefix + "rotation": "9",
+			},
+			expected: Config{
+				BackupCronExpression: "@hourly",
+				BackupArchive:        "/tmp",
+				BackupRetentionDays:  9,
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/test/labels/docker-compose.yml
+++ b/test/labels/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     environment:
       BACKUP_FILENAME: test.tar.gz
     volumes:
+      # TODO: why do we need to mount the volume of the other service?
+      #     why it cannot mount it by its own?
       - app_data:/backup/app_data:ro
       - ${LOCAL_DIR:-./local}:/archive
       - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/test/labels/docker-compose.yml
+++ b/test/labels/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  data:
+    image: alpine:3.17.3
+    command: ["/bin/sh", "-c", "mkdir -p /data && echo 'hello' > /data/foo.txt && sleep infinity"]
+    volumes:
+      - app_data:/data
+
+  backup:
+    image: offen/docker-volume-backup:${TEST_VERSION:-canary}
+    command: ["--config-style=labels"]
+    environment:
+      BACKUP_FILENAME: test.tar.gz
+    volumes:
+      - app_data:/backup/app_data:ro
+      - ${LOCAL_DIR:-./local}:/archive
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+
+volumes:
+  app_data:
+    labels:
+      dvbackup.schedule: "@daily"
+      dvbackup.target: "/archive"
+      dvbackup.rotation: "7"

--- a/test/labels/run.sh
+++ b/test/labels/run.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -e
+
+cd "$(dirname "$0")"
+. ../util.sh
+current_test=$(basename $(pwd))
+
+export LOCAL_DIR=$(mktemp -d)
+
+docker compose up -d --quiet-pull
+sleep 5
+
+docker compose exec backup backup
+
+sleep 5
+
+expect_running_containers "2"
+
+tmp_dir=$(mktemp -d)
+tar -xvf "$LOCAL_DIR/test.tar.gz" -C "$tmp_dir"
+if [ ! -f "$tmp_dir/backup/app_data/foo.txt" ]; then
+  fail "Could not find expected file in untared archive."
+fi
+
+pass "Found relevant file in untared local backup."


### PR DESCRIPTION
## Summary
- add integration test that uses label-based configuration
- document current Swarm limitations and new helper container proposal
- refine Swarm issues by removing obsolete docs task and breaking helper work into three issues

## Testing
- `go fmt ./...` *(fails: proxy.golang.org access blocked)*
- `golangci-lint run` *(fails: can't load config)*
- `go test ./...` *(fails: proxy.golang.org access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6863230e4db8832793639d248172e316