### PR TITLE
Add configurable label prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ volumes:
 You can also provide all configuration via Docker volume labels. Start the
 `backup` service with `--config-style=labels` and attach configuration labels to
 your volumes using the `dvbackup.` prefix. When running with this option,
-environment files are ignored:
+environment files are ignored. The prefix can be changed using `--label-prefix`
+or the `LABEL_PREFIX` environment variable:
 
 ```yml
 services:

--- a/cmd/backup/main.go
+++ b/cmd/backup/main.go
@@ -5,13 +5,23 @@ package main
 
 import (
 	"flag"
+	"os"
+
+	"github.com/offen/docker-volume-backup/internal/labels"
 )
 
 func main() {
 	foreground := flag.Bool("foreground", false, "run the tool in the foreground")
 	profile := flag.String("profile", "", "collect runtime metrics and log them periodically on the given cron expression")
 	configStyle := flag.String("config-style", "envfile", "load configuration from envfile (default) or labels")
+	labelPrefix := flag.String("label-prefix", labels.Prefix, "prefix used for configuration labels")
 	flag.Parse()
+
+	prefix := *labelPrefix
+	if env := os.Getenv("LABEL_PREFIX"); env != "" {
+		prefix = env
+	}
+	labels.Prefix = prefix
 
 	c := newCommand()
 	if *foreground {

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,7 +72,9 @@ volumes:
 
 You can also supply configuration via Docker volume labels by running the
 `backup` service with `--config-style=labels` and attaching configuration labels
-to your volumes. When this option is used, environment files are ignored:
+to your volumes. When this option is used, environment files are ignored. The
+label prefix defaults to `dvbackup.` and can be changed using `--label-prefix` or
+the `LABEL_PREFIX` environment variable:
 
 ```yml
 services:

--- a/internal/labels/labels.go
+++ b/internal/labels/labels.go
@@ -4,4 +4,6 @@
 package labels
 
 // Prefix is the namespace used when scanning Docker volumes for configuration labels.
-const Prefix = "dvbackup."
+// It can be overridden at runtime using the `--label-prefix` flag or the
+// `LABEL_PREFIX` environment variable.
+var Prefix = "dvbackup."


### PR DESCRIPTION
## Summary
- allow overriding the volume label prefix via `--label-prefix` flag or `LABEL_PREFIX` env var
- document label prefix override in README and docs

## Testing
- `go fmt ./...`
- `golangci-lint run` *(fails: can't load config)*

------
https://chatgpt.com/codex/tasks/task_e_686aa56106e8832797f2899d7cdafaff